### PR TITLE
link to public page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Our mission is to create a sustainable source of funding to enable continuous im
 - **Transparent use of funds:** Open Elements manages funding transparently and reports regularly on the progress of milestones.
 - **Development by experts:** Our work is carried out by leading Maven experts.
 
+For more details, see [our public page](https://open-elements.com/support-care-maven/#our-mission).
+
 ## Next steps
 
 We will have an open milestone planning at the [JSail](https://jsail.ijug.eu) unconference. That meeting will be done as a face-2-face meeting.


### PR DESCRIPTION
having a link back from "public page" (don't hesitate to change if you find a better name) to the planning GH repository would also be useful